### PR TITLE
Updated .gitignore, to prevent any ENV file becoming a part of repo …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,8 @@ celerybeat.pid
 *.sage.py
 
 # Environments
+**/*.env
+**/*.venv
 .env
 .venv
 env/


### PR DESCRIPTION
This fixes a possible security leak. If ENV files are prevented from becoming part of repo, it is a good security measure.